### PR TITLE
Remove Projects tab from navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,5 +3,3 @@
 - title: Courses
   url: /courses/
 
-- title: Projects
-  url: /projects/

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -41,9 +41,6 @@ layout: compress
                          <a class="btn zoombtn" href="{{ site.url }}/courses">
                          Courses
                          </a>
-                         <a class="btn zoombtn" href="{{ site.url }}/projects">
-                         Projects
-                         </a>
                  </h3>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove Projects from `_data/navigation.yml`
- update `home.html` navigation buttons accordingly

## Testing
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685cc0ed27188332ad4955e231ca69bb