### PR TITLE
Fix GitHub Pages build by excluding large folders

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,12 @@ title: "Stan Neo - Career and Consulting Services"
 description: Coaching, Mock Interviews, CV Reviews, and more.
 url: "https://nhanwei.github.io" 
 github_username: nhanwei
+exclude:
+  - node_modules
+  - vendor
+  - Gemfile
+  - Gemfile.lock
+  - package.json
+  - package-lock.json
+  - postcss.config.js
+  - tailwind.config.js


### PR DESCRIPTION
## Summary
- exclude `node_modules`, `vendor`, and other build files from the Jekyll build

## Testing
- `bundle exec jekyll build` *(fails: Could not find github-pages-231)*

------
https://chatgpt.com/codex/tasks/task_e_687dfff635f883329c9c1480bcd3b586